### PR TITLE
Improved Anti-Tamper detection

### DIFF
--- a/NoFuserEx/NoFuserEx/Deobfuscator/Deobfuscators/AntiTamperDeobfuscator.cs
+++ b/NoFuserEx/NoFuserEx/Deobfuscator/Deobfuscators/AntiTamperDeobfuscator.cs
@@ -60,11 +60,14 @@ namespace NoFuserEx.Deobfuscator.Deobfuscators {
         static bool? IsTampered(ModuleDefMD module) {
             var sections = module.MetaData.PEImage.ImageSectionHeaders;
 
-            if (sections.Count == 3) {
-                Logger.Verbose("Anti-tamper not detected.");
+            // There should be at least a .text and a .rsrc section
+            if (sections.Count < 3) {
+                Logger.Verbose("Anti-tamper should not be present.");
                 return false;
             }
 
+            // If more than 2 sections, test the names (the name of the section
+            // created by ConfuserEx is random)
             foreach (var section in sections) {
                 switch (section.DisplayName) {
                     case ".text":
@@ -76,6 +79,14 @@ namespace NoFuserEx.Deobfuscator.Deobfuscators {
                         return true;
                 }
             }
+            
+            // If there were only .text, .rsrc and .reloc sections
+            // Then the protection is absent
+            if (sections.Count == 3) {
+                Logger.Verbose("Anti-tamper should not detected.");
+                return false;
+            }
+            
             return null;
         }
 


### PR DESCRIPTION
Hi !

Working on confused samples with ConfuserEx v1.0.0, I noticed the anti-tamper detection didn't catch some cases. This PR offers some slight edition to catch the case described below.

Here is an example of a dummy .NET executable being confused:

Before confusion with anti-tamper:

```
[*]   SimpleDotNet_anti-tamper.exe
+-------+---------+-------------+------------------+-------------+-------------------+----+---+---+---+---+----------------------------------+---------+--------+------+-----+
| Name  | RVA     | VirtualSize | PointerToRawData | RawDataSize | Entropy           | EP | R | W | X | S | MD5                              | # Reloc | Relocs | # LN | LN  |
+-------+---------+-------------+------------------+-------------+-------------------+----+---+---+---+---+----------------------------------+---------+--------+------+-----+
| .text | 0x2000  | 0x1b39c     | 512              | 111616      | 7.960411437897488 |    | x |   | x |   | 12509d05d1577976180724ec32d03683 | 0x0     | 0x0    | 0x0  | 0x0 |
| .rsrc | 0x1e000 | 0x5fc       | 112128           | 1536        | 4.187690645126408 |    | x |   |   |   | d22b900f12aa137621868ea1b2e0e107 | 0x0     | 0x0    | 0x0  | 0x0 |
+-------+---------+-------------+------------------+-------------+-------------------+----+---+---+---+---+----------------------------------+---------+--------+------+-----+
```

After confusion with anti-tamper only:

```
[*]   Confused/SimpleDotNet_anti-tamper.exe
+----------+---------+-------------+------------------+-------------+-------------------+----+---+---+---+---+----------------------------------+---------+--------+------+-----+
| Name     | RVA     | VirtualSize | PointerToRawData | RawDataSize | Entropy           | EP | R | W | X | S | MD5                              | # Reloc | Relocs | # LN | LN  |
+----------+---------+-------------+------------------+-------------+-------------------+----+---+---+---+---+----------------------------------+---------+--------+------+-----+
| rIKf4lx | 0x2000  | 0x198       | 512              | 512         | 7.60673719754518  |    | x | x | x |   | 914997f6ca6a979068f1c52ca49d8fff | 0x0     | 0x0    | 0x0  | 0x0 |
| .text    | 0x4000  | 0x1b700     | 1024             | 112640      | 7.961884587098321 |    | x |   | x |   | a14b15520ce026e50637ee8901de5314 | 0x0     | 0x0    | 0x0  | 0x0 |
| .rsrc    | 0x20000 | 0x5f8       | 113664           | 1536        | 4.176861570230687 |    | x |   |   |   | 8ca34402811171785fe108ea004092e2 | 0x0     | 0x0    | 0x0  | 0x0 |
+----------+---------+-------------+------------------+-------------+-------------------+----+---+---+---+---+----------------------------------+---------+--------+------+-----+
```
In this case, current NoFuserEx on the master branch will think there is no protection, but it actually is there.


